### PR TITLE
properly handle effect teardown function in DEBUG mode

### DIFF
--- a/addon/-private/effect.js
+++ b/addon/-private/effect.js
@@ -22,7 +22,7 @@ if (DEBUG) {
     shouldAssert = true;
 
     try {
-      fn();
+      return fn();
     } finally {
       shouldAssert = false;
     }

--- a/tests/dummy/app/components/use-effect-demo.js
+++ b/tests/dummy/app/components/use-effect-demo.js
@@ -1,0 +1,12 @@
+import Component from '@glimmer/component'
+import { use, effect } from 'ember-usable'
+
+export default class UseEffectDemo extends Component {
+  constructor(...args) {
+    super(...args)
+    use(this, effect(() => {
+      console.log('running effect...')
+      return () => console.log('stopping effect...')
+    }))
+  }
+}

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -5,6 +5,7 @@ import { tracked } from '@glimmer/tracking';
 export default class ApplicationController extends Controller {
   @tracked interval = 1000;
   @tracked showCount = true;
+  @tracked runEffectDemo = true;
 
   @action
   toggleShowCount() {
@@ -21,5 +22,10 @@ export default class ApplicationController extends Controller {
     if (this.interval !== 100) {
       this.interval = this.interval - 100;
     }
+  }
+
+  @action
+  toggleEffectDemo() {
+    this.runEffectDemo = !this.runEffectDemo
   }
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -4,6 +4,9 @@
   <button type="button" {{on "click" this.toggleShowCount}}>
     Show Count
   </button>
+  <button type="button" {{on "click" this.toggleEffectDemo}}>
+    {{if this.runEffectDemo 'Stop' 'Start'}} effect demo
+  </button>
 </div>
 
 <div>
@@ -19,4 +22,10 @@
 
 <div>
   <TaskDemo @url={{this.interval}}/>
+</div>
+
+<div>
+  {{#if this.runEffectDemo}}
+    <UseEffectDemo />
+  {{/if}}
 </div>


### PR DESCRIPTION
This PR fixes a bug found on the `initial-implementation` branch referenced here #4. 

The issue involved a debug helper named `assertOnDirty` which calls the effect function with some debug assertions. It was calling the effect function, but wasn't returning the teardown function. Meanwhile the `setupUsable` hook was expecting the teardown function to be returned. This bug resulted in the teardown function being stored as undefined, and was therefore never invoked during the `teardownUsable` hook.

This PR also includes a dummy test for demonstrating the effect usable with a teardown function