### PR TITLE
Simplify named argument usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,49 @@ If you provide an `update` function in your resource, this will be called every 
 You can also provide named arguments to a resource, which are available via `this.args.named`.
 
 
+## Usage with TypeScript
+
+There is a helper function that can be imported to give a hint to TypeScript
+that the value of a Resource is different from the instance of a Resource.
+
+```ts
+import Component from '@glimmer/component';
+import { use, valueFor } from 'ember-could-get-used-to-this';
+import Counter from 'my-app/helpers/counter';
+
+interface Args {
+  interval: number;
+}
+
+export default class CounterWrapper extends Component<Args> {
+  // count is of type `number`
+  @use count = valueFor(new Counter(() => [this.args.interval]));
+}
+```
+
+The Resource definition itself has a generic type argument similar to Modifiers:
+
+```ts
+interface Args {
+  positional: [number];
+}
+
+class Counter extends Resource<Args> {
+  @tracked count = 0;
+  // ...
+}
+```
+
+But by contrast to Modifiers, the default Args type for a Resource is
+```ts
+export type LazyTrackedArgs = {
+  positional?: Array<unknown>;
+  named?: Record<string, unknown>;
+};
+```
+due to the differing ways a Resource can be passed args.
+
+
 Contributing
 ------------------------------------------------------------------------------
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,25 +1,25 @@
-import { invokeHelper } from '@ember/helper';
-import { getValue } from '@glimmer/tracking/primitives/cache';
+import {invokeHelper} from '@ember/helper';
+import {getValue} from '@glimmer/tracking/primitives/cache';
 
-export { modifier, Modifier } from './-private/modifiers';
-export { Resource } from './-private/resources';
+export {modifier, Modifier} from './-private/modifiers';
+export {Resource} from './-private/resources';
 
 export function use(prototype, key, desc) {
   let resources = new WeakMap();
-  let { initializer } = desc;
+  let {initializer} = desc;
 
   return {
     get() {
       let resource = resources.get(this);
 
       if (!resource) {
-        let { definition, args } = initializer.call(this);
+        let {definition, args} = initializer.call(this);
 
         resource = invokeHelper(this, definition, () => {
           let reified = args();
 
           if (Array.isArray(reified)) {
-            return { positional: reified };
+            return {positional: reified};
           }
 
           return reified;
@@ -30,4 +30,19 @@ export function use(prototype, key, desc) {
       return getValue(resource);
     }
   }
+}
+
+/**
+  * Since TS doesn't allow decorators to change their type,
+  * this helper function, similar to taskFor from ember-concurrency-ts,
+  * only changes the type.
+  *
+  * @example
+  *   // counter will have the correct type, and not be the type of an instance of Counter
+  *   @use counter = valueFor(new Counter(...));
+  *
+  *
+  */
+export function valueFor(instance) {
+  return instance;
 }

--- a/addon/index.js
+++ b/addon/index.js
@@ -20,6 +20,8 @@ export function use(prototype, key, desc) {
 
           if (Array.isArray(reified)) {
             return { positional: reified };
+          } else if (!('named' in reified)) {
+            return { named: reified };
           }
 
           return reified;

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,25 +1,25 @@
-import {invokeHelper} from '@ember/helper';
-import {getValue} from '@glimmer/tracking/primitives/cache';
+import { invokeHelper } from '@ember/helper';
+import { getValue } from '@glimmer/tracking/primitives/cache';
 
-export {modifier, Modifier} from './-private/modifiers';
-export {Resource} from './-private/resources';
+export { modifier, Modifier } from './-private/modifiers';
+export { Resource } from './-private/resources';
 
 export function use(prototype, key, desc) {
   let resources = new WeakMap();
-  let {initializer} = desc;
+  let { initializer } = desc;
 
   return {
     get() {
       let resource = resources.get(this);
 
       if (!resource) {
-        let {definition, args} = initializer.call(this);
+        let { definition, args } = initializer.call(this);
 
         resource = invokeHelper(this, definition, () => {
           let reified = args();
 
           if (Array.isArray(reified)) {
-            return {positional: reified};
+            return { positional: reified };
           }
 
           return reified;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,23 @@
+export type LazyTrackedArgs = {
+  positional?: Array<unknown>;
+  named?: Record<string, unknown>;
+};
+
+type ConstructorFn<Args extends LazyTrackedArgs> = (() => Args) | (() => Args['positional']);
+
+export const use: PropertyDecorator;
+export class Resource<Args extends LazyTrackedArgs> {
+  protected args: Args;
+
+  // This is a lie, but makes the call site nice.
+  // Resources should not define a constructor.
+  constructor(fn: ConstructorFn<Args>);
+
+  get value(): unknown;
+}
+
+/**
+ * No-op TypeScript helper for helping reshape the type of the Resource in TypeScript files
+ */
+export function valueFor<SomeResource extends Resource<LazyTrackedArgs>>(instance: SomeResource): SomeResource['value'];
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ export type LazyTrackedArgs = {
   named?: Record<string, unknown>;
 };
 
-type ConstructorFn<Args extends LazyTrackedArgs> = (() => Args) | (() => Args['positional']);
+type ConstructorFn<Args extends LazyTrackedArgs> = (() => Args) | (() => Args['positional']) | (() => Args['named']);
 
 export const use: PropertyDecorator;
 export class Resource<Args extends LazyTrackedArgs> {

--- a/tests/integration/use-test.js
+++ b/tests/integration/use-test.js
@@ -4,45 +4,94 @@ import { tracked } from 'tracked-built-ins';
 import { use, Resource } from 'ember-could-get-used-to-this';
 
 module('@use', () => {
-  test('it works', async function (assert) {
-    class TestResource extends Resource {
-      @tracked value;
+  module('positional args', function() {
+    test('it works', async function (assert) {
+      class TestResource extends Resource {
+        @tracked value;
 
-      setup() {
-        this.value = this.args.positional[0];
+        setup() {
+          this.value = this.args.positional[0];
+        }
       }
-    }
 
-    class MyClass {
-      @use test = new TestResource(() => ['hello'])
-    }
+      class MyClass {
+        @use test = new TestResource(() => ['hello'])
+      }
 
-    let instance = new MyClass();
+      let instance = new MyClass();
 
-    assert.equal(instance.test, 'hello');
+      assert.equal(instance.test, 'hello');
+    });
+
+    test('resources update if args update', async function (assert) {
+      class TestResource extends Resource {
+        @tracked value;
+
+        setup() {
+          this.value = this.args.positional[0];
+        }
+      }
+
+      class MyClass {
+        @tracked text = 'hello'
+
+        @use test = new TestResource(() => [this.text])
+      }
+
+      let instance = new MyClass();
+
+      assert.equal(instance.test, 'hello');
+
+      instance.text = 'world';
+
+      assert.equal(instance.test, 'world');
+    });
   });
 
-  test('resources update if args update', async function (assert) {
-    class TestResource extends Resource {
-      @tracked value;
+  module('named args', function() {
 
-      setup() {
-        this.value = this.args.positional[0];
+    test('it works', async function (assert) {
+      class TestResource extends Resource {
+        @tracked value;
+
+        setup() {
+          this.value = this.args.named.str;
+        }
       }
-    }
 
-    class MyClass {
-      @tracked text = 'hello'
+      class MyClass {
+        @use test = new TestResource(() => ({ str: 'hello'}))
+      }
 
-      @use test = new TestResource(() => [this.text])
-    }
+      let instance = new MyClass();
 
-    let instance = new MyClass();
+      assert.equal(instance.test, 'hello');
+    });
 
-    assert.equal(instance.test, 'hello');
 
-    instance.text = 'world';
+    test('resources update if args update', async function (assert) {
+      class TestResource extends Resource {
+        @tracked value;
 
-    assert.equal(instance.test, 'world');
+        setup() {
+          this.value = this.args.named.str;
+        }
+      }
+
+      class MyClass {
+        @tracked text = 'hello'
+
+        @use test = new TestResource(() => ({ str: this.text }))
+      }
+
+      let instance = new MyClass();
+
+      assert.equal(instance.test, 'hello');
+
+      instance.text = 'world';
+
+      assert.equal(instance.test, 'world');
+    });
+
   });
 });


### PR DESCRIPTION
depends on: https://github.com/pzuraq/ember-could-get-used-to-this/pull/30/files

instead of specifying 

```ts
() => ( {
    named: {...}
  } )
```
we can now do, like we do with positional:
```ts
() => ( {
...
  } )
```