### PR TITLE
Change the ResourceManager to return the Resource instance instead of…

### DIFF
--- a/addon/-private/resources.js
+++ b/addon/-private/resources.js
@@ -68,7 +68,7 @@ class ResourceManager {
   getValue(cache) {
     let instance = getValue(cache);
 
-    return instance.value;
+    return instance;
   }
 
   getDestroyable(cache) {

--- a/tests/integration/resources-test.js
+++ b/tests/integration/resources-test.js
@@ -22,7 +22,11 @@ module('resources', (hooks) => {
       }
     );
 
-    await render(hbs`{{test-resource 'hello'}}`);
+    await render(hbs`
+      {{#let (test-resource 'hello') as |test|}}
+        {{test.value}}
+      {{/let}}
+    `);
 
     assert.equal(this.element.textContent.trim(), 'hello');
   });
@@ -41,7 +45,11 @@ module('resources', (hooks) => {
 
     this.text = 'hello';
 
-    await render(hbs`{{test-resource this.text}}`);
+    await render(hbs`
+      {{#let (test-resource this.text) as |test|}}
+        {{test.value}}
+      {{/let}}
+    `);
 
     assert.equal(this.element.textContent.trim(), 'hello');
 
@@ -66,7 +74,11 @@ module('resources', (hooks) => {
 
     this.value = tracked({ text: 'hello' });
 
-    await render(hbs`{{test-resource this.value}}`);
+    await render(hbs`
+      {{#let (test-resource this.value) as |test|}}
+        {{test.value}}
+      {{/let}}
+    `);
 
     assert.equal(this.element.textContent.trim(), 'hello');
 
@@ -98,7 +110,13 @@ module('resources', (hooks) => {
 
     this.text = 'hello';
 
-    await render(hbs`{{#if this.show}}{{test-resource this.text}}{{/if}}`);
+    await render(hbs`
+      {{#if this.show}}
+        {{#let (test-resource this.text) as |test|}}
+          {{test.value}}
+        {{/let}}
+      {{/if}}
+    `);
 
     assert.equal(this.element.textContent.trim(), '');
     assert.equal(active, 0, 'no active resources yet');
@@ -139,7 +157,11 @@ module('resources', (hooks) => {
 
     this.text = 'hello';
 
-    await render(hbs`{{test-resource this.text}}`);
+    await render(hbs`
+      {{#let (test-resource this.text) as |test|}}
+        {{test.value}}
+      {{/let}}
+    `);
 
     assert.equal(this.element.textContent.trim(), 'hello');
     assert.equal(resources.size, 1, 'one resource class created');
@@ -163,7 +185,11 @@ module('resources', (hooks) => {
       }
     );
 
-    await render(hbs`{{test-resource text='hello'}}`);
+    await render(hbs`
+      {{#let (test-resource text='hello') as |test|}}
+        {{test.value}}
+      {{/let}}
+    `);
 
     assert.equal(this.element.textContent.trim(), 'hello');
   });
@@ -189,7 +215,11 @@ module('resources', (hooks) => {
 
     this.text = 'hello';
 
-    await render(hbs`{{test-resource this.text}}`);
+    await render(hbs`
+      {{#let (test-resource this.text) as |test|}}
+        {{test.value}}
+      {{/let}}
+    `);
 
     assert.equal(this.element.textContent.trim(), 'hello');
     assert.equal(resources.size, 1, 'one resource class created');
@@ -220,16 +250,16 @@ module('resources', (hooks) => {
       'helper:test-resource',
       class extends Resource {
         @service text;
-
-        get value() {
-          return this.text.text;
-        }
       }
     );
 
     this.text = 'hello';
 
-    await render(hbs`{{test-resource this.text}}`);
+    await render(hbs`
+      {{#let (test-resource this.text) as |test|}}
+        {{test.text.text}}
+      {{/let}}
+    `);
 
     assert.equal(this.element.textContent.trim(), 'hello');
 
@@ -244,12 +274,6 @@ module('resources', (hooks) => {
 
     class LoadData extends Resource {
       @tracked isLoading = true;
-
-      get value() {
-        return {
-          isLoading: this.isLoading,
-        };
-      }
 
       setup() {
         assert.step('setup');

--- a/tests/integration/use-test.js
+++ b/tests/integration/use-test.js
@@ -6,10 +6,10 @@ import { use, Resource } from 'ember-could-get-used-to-this';
 module('@use', () => {
   test('it works', async function (assert) {
     class TestResource extends Resource {
-      @tracked value;
+      @tracked firstArg;
 
       setup() {
-        this.value = this.args.positional[0];
+        this.firstArg = this.args.positional[0];
       }
     }
 
@@ -19,15 +19,15 @@ module('@use', () => {
 
     let instance = new MyClass();
 
-    assert.equal(instance.test, 'hello');
+    assert.equal(instance.test.firstArg, 'hello');
   });
 
   test('resources update if args update', async function (assert) {
     class TestResource extends Resource {
-      @tracked value;
+      @tracked firstArg;
 
       setup() {
-        this.value = this.args.positional[0];
+        this.firstArg = this.args.positional[0];
       }
     }
 
@@ -39,10 +39,10 @@ module('@use', () => {
 
     let instance = new MyClass();
 
-    assert.equal(instance.test, 'hello');
+    assert.equal(instance.test.firstArg, 'hello');
 
     instance.text = 'world';
 
-    assert.equal(instance.test, 'world');
+    assert.equal(instance.test.firstArg, 'world');
   });
 });


### PR DESCRIPTION
with the instance returned instead of `value`, the typescript implementation is simplified a lot / no need for `valueFor` as proposed here: https://github.com/pzuraq/ember-could-get-used-to-this/pull/30/files#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8R26 (similar to what ember-concurrency-ts does)