### PR TITLE
Add consistent quotes eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,8 @@ module.exports = {
     browser: true
   },
   rules: {
-    'ember/no-jquery': 'error'
+    'ember/no-jquery': 'error',
+    'quotes': ['error', 'single'],
   },
   overrides: [
     // node files

--- a/addon/-private/modifiers.js
+++ b/addon/-private/modifiers.js
@@ -6,7 +6,7 @@ import { destroy, registerDestructor } from '@ember/destroyable';
 import { setOwner } from '@ember/application';
 
 class FunctionalModifierManager {
-  capabilities = modifierCapabilities("3.22");
+  capabilities = modifierCapabilities('3.22');
 
   createModifier(fn, args) {
     return { fn, args, element: undefined, destructor: undefined };
@@ -58,7 +58,7 @@ export class Modifier {
 }
 
 class ClassModifierManager {
-  capabilities = modifierCapabilities("3.22");
+  capabilities = modifierCapabilities('3.22');
 
   constructor(owner) {
     this.owner = owner;

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,50 +1,50 @@
-"use strict";
+'use strict';
 
-const getChannelURL = require("ember-source-channel-url");
+const getChannelURL = require('ember-source-channel-url');
 
 module.exports = async function () {
   return {
     useYarn: true,
     scenarios: [
       {
-        name: "ember-lts-3.24",
+        name: 'ember-lts-3.24',
         npm: {
           devDependencies: {
-            "ember-source": await getChannelURL("release"),
+            'ember-source': await getChannelURL('release'),
           },
         },
       },
       {
-        name: "ember-release",
+        name: 'ember-release',
         npm: {
           devDependencies: {
-            "ember-source": await getChannelURL("release"),
+            'ember-source': await getChannelURL('release'),
           },
         },
       },
       {
-        name: "ember-beta",
+        name: 'ember-beta',
         npm: {
           devDependencies: {
-            "ember-source": await getChannelURL("beta"),
+            'ember-source': await getChannelURL('beta'),
           },
         },
       },
       {
-        name: "ember-canary",
+        name: 'ember-canary',
         npm: {
           devDependencies: {
-            "ember-source": await getChannelURL("canary"),
+            'ember-source': await getChannelURL('canary'),
           },
         },
       },
       {
-        name: "embroider",
+        name: 'embroider',
         npm: {
           devDependencies: {
-            "@embroider/core": "*",
-            "@embroider/webpack": "*",
-            "@embroider/compat": "*",
+            '@embroider/core': '*',
+            '@embroider/webpack': '*',
+            '@embroider/compat': '*',
           },
         },
       },


### PR DESCRIPTION
It's hard to manually revert quote changes due to a misconfigured editor (oops),

This PR automates consistent quotes in JS files.